### PR TITLE
Fix typo on totalPages

### DIFF
--- a/lib/paginate-array.js
+++ b/lib/paginate-array.js
@@ -22,7 +22,7 @@ exports.default = function (collection) {
     currentPage: currentPage,
     perPage: perPage,
     total: collection.length,
-    totaPages: Math.ceil(collection.length / perPage),
+    totalPages: Math.ceil(collection.length / perPage),
     data: paginatedItems
   };
 };


### PR DESCRIPTION
There was missing `l` in `totalPages` object property in `lib/paginate-array.js`. Took me some time to realize. Anyway thanks for the plugin :)